### PR TITLE
fix : 로그인 직후 친구 목록 반영 안 되는 문제 + 즐겨찾기 시 즐겨찾기 목록, 친구 목록 중복 현상

### DIFF
--- a/src/apis/getFriendList.ts
+++ b/src/apis/getFriendList.ts
@@ -1,15 +1,10 @@
 import { customedAxios } from './customedAxios';
 import api from '../service/TokenService';
 
-const accessToken = api.getAccessToken();
-
-export const getFriendList = async (data: FriendListReq): Promise<FriendListRes> => {
+export const getFriendList = async (): Promise<FriendListRes> => {
   const res = await customedAxios.get('/members/friends', {
-    params: {
-      page: data.page,
-    },
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${api.getAccessToken()}`,
     },
   });
   return res.data;

--- a/src/apis/postLike.ts
+++ b/src/apis/postLike.ts
@@ -1,8 +1,6 @@
 import { customedAxios } from './customedAxios';
 import api from '../service/TokenService';
 
-const accessToken = api.getAccessToken();
-
 export const postLike = async (data: PostLikeReq): Promise<PostLikeRes> => {
   const res = await customedAxios.post(
     `/members/friends/${data.friendId}/likes`,
@@ -12,9 +10,9 @@ export const postLike = async (data: PostLikeReq): Promise<PostLikeRes> => {
         isLiked: data.isLiked,
       },
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${api.getAccessToken()}`,
       },
     }
   );
-  return res.data;
+  return { status: res.status };
 };

--- a/src/components/Friend/UserFriend/UserFriend.style.ts
+++ b/src/components/Friend/UserFriend/UserFriend.style.ts
@@ -6,6 +6,7 @@ export const FriendContainer = styled.div`
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
+  cursor: pointer;
 
   // 스크롤 바 안 생기게
   -ms-overflow-style: none;

--- a/src/types/Friend.ts
+++ b/src/types/Friend.ts
@@ -17,17 +17,12 @@ interface Friend {
   onLikeToggle: (friendId: number, isLiked: boolean) => void;
 }
 
-interface FriendListReq {
-  page: number;
-}
-
 interface PostLikeReq {
   friendId: number;
   isLiked: boolean;
 }
 interface PostLikeRes {
   status: number;
-  message: string;
 }
 
 interface FriendDetail {


### PR DESCRIPTION
### 🔥 Related Issues
#39 

---
### ✨ 작업 내용

- [x] 로그인 한 뒤 새로고침 없이도 친구 목록 불러오도록 수정

- [x] 즐겨찾기 시 즐겨찾기 목록, 친구 목록에 중복 되는 현상 -> 즐겨찾기 시 친구 목록에서 빼기


---
### 👀 구현 결과물

https://github.com/Squash-io/squash-frontend/assets/127850874/fe4b4399-e336-4d0a-9949-761926179936

